### PR TITLE
Add missing comma in the file

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -97,7 +97,7 @@
     "type": "effect_on_condition",
     "id": "EOC_MINOR_SLEEP",
     "effect": [ { "message": "You feel sleepy…" }, { "u_mod_fatigue": 20 } ]
-  }
+  },
   {
   "type": "effect_on_condition",
     "id": "night_messages",


### PR DESCRIPTION
Recent change introduced mini bug, missing `comma` in the file - `experimental` version.